### PR TITLE
[Dev #MIND-137] - Add Travis automatic validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
-env: JAVA_HOME=/usr/lib/jvm/java-7-oracle/
 install: mvn -U clean -PCI-profile
-script: mvn -U verify -PCI-profile -DJAVA_HOME=/usr/lib/jvm/java-7-oracle/
+script: mvn -U verify -PCI-profile

--- a/mindc/src/assemble/resources/mindc
+++ b/mindc/src/assemble/resources/mindc
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # ------------------------------------------------------------------------------
 # Copyright (C) 2009 STMicroelectronics
@@ -121,11 +121,12 @@ LAUNCHER=org.ow2.mind.Launcher
 ## Preparation of the java command to be executed
 if [ -z "$JAVACMD" ] ; then
   if [ -n "$JAVA_HOME"  ] ; then
-    echo TDR $JAVA_HOME
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
       # IBM's JDK on AIX uses strange locations for the executables
       JAVACMD="$JAVA_HOME/jre/sh/java"
-    else
+    elif [ -x "$JAVA_HOME" ] ; then
+      JAVACMD="$JAVA_HOME"
+    else 
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else


### PR DESCRIPTION
In order to automate validation of mindc modification, I have added a .travis.yml configuration file.
It also fix the usage of JAVA_HOME environment variable at test time.

See http://jira.ow2.org/browse/MIND-137 for more details
