### PR TITLE
Itf inheritance cast

### DIFF
--- a/adl-backend/src/main/resources/st/instances/Component.stc
+++ b/adl-backend/src/main/resources/st/instances/Component.stc
@@ -156,16 +156,16 @@ AddItfValue(definition, instance, itf, isInternal) ::= <<
 <if (itf.numberOfElement)>
 <itf.astDecorations.("collectionIndexes"):AddItfCollectionValue(definition=definition, instance=instance, itf=itf, index=it, isInternal=isInternal);separator="\n">
 <else>
-, /* <itf.name> */ <StaticBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)))>
+, /* <itf.name> */ <BindingCastIfNeeded(instance=instance, itf=itf, isInternal=isInternal)><StaticBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)))>
 <endif>
 <endif>
 >>
 
 AddItfCollectionValue(definition, instance, itf, index, isInternal) ::= <<
 <if (instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, index=index, isInternal=isInternal)))>
-, /* <itf.name>[<index>] */ <StaticBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, index=index, isInternal=isInternal)))>
+, /* <itf.name>[<index>] */ <CollectionBindingCastIfNeeded(instance=instance, itf=itf, index=index, isInternal=isInternal)><StaticBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, index=index, isInternal=isInternal)))>
 <else>
-, /* <itf.name>[<index>] */ <StaticCollectionBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)), index=index)>
+, /* <itf.name>[<index>] */ <CollectionBindingCastIfNeeded(instance=instance, itf=itf, index=index, isInternal=isInternal)><StaticCollectionBindingValue(bindingDesc=instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)), index=index)>
 <endif>
 >>
 
@@ -190,6 +190,9 @@ StaticCollectionBindingValue(bindingDesc, index) ::= <<
 >>
 
 StaticBindingItfName(itfName, index, isInternal) ::= "<if (isInternal)>INTERNAL_<endif><itfName><if (index)>_<index><endif>"
+
+BindingCastIfNeeded(instance, itf, isInternal) ::= << <if (instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)).binding.astDecorations.("type-inheritance-cast"))>(<instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)).binding.astDecorations.("type-inheritance-cast"); format="toCName">)<endif> >>
+CollectionBindingCastIfNeeded(instance, itf, index, isInternal) ::= << <if (instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, index=index, isInternal=isInternal)).binding.astDecorations.("type-inheritance-cast"))>(<instance.decorations.("binding-descriptors").(StaticBindingItfName(itfName=itf.name, index=index, isInternal=isInternal)).binding.astDecorations.("type-inheritance-cast"); format="toCName">)<endif> >>
 
 DefineAttributeValues(definition, instance) ::= <<
 <if (definition.astNodeTypes.("attribute"))>

--- a/adl-backend/src/main/resources/st/membrane/MembraneImplementation.stc
+++ b/adl-backend/src/main/resources/st/membrane/MembraneImplementation.stc
@@ -255,10 +255,12 @@ InitializeBindings(definition) ::= <<
 >>
 
 InitializeBinding(definition, binding) ::= <<
-  /* initialize binding from <binding.fromComponent>.<binding.fromInterface> to <binding.toComponent>.<binding.toInterface> */
+  /* initialize binding from <binding.fromComponent>.<binding.fromInterface><if(binding.fromInterfaceNumber)>[<binding.fromInterfaceNumber>]<endif> to <binding.toComponent>.<binding.toInterface><if(binding.toInterfaceNumber)>[<binding.toInterfaceNumber>]<endif> */
   newInstance->__component_internal_data.<FromItfContainer(binding=binding)>.<binding.fromInterface><if(binding.fromInterfaceNumber)>[<binding.fromInterfaceNumber>]<endif> = 
-    & newInstance->__component_internal_data.<ToItfContainer(binding=binding)>.<binding.toInterface><if(binding.toInterfaceNumber)>[<binding.toInterfaceNumber>]<endif>;
+    <BindingCastIfNeeded(binding=binding)>& newInstance->__component_internal_data.<ToItfContainer(binding=binding)>.<binding.toInterface><if(binding.toInterfaceNumber)>[<binding.toInterfaceNumber>]<endif>;
 >>
+
+BindingCastIfNeeded(binding) ::= << <if (binding.astDecorations.("type-inheritance-cast"))>(<binding.astDecorations.("type-inheritance-cast"); format="toCName">)<endif> >>
 
 FromItfContainer(binding) ::= <<
 <if (isThis.(binding.fromComponent))>

--- a/adl-backend/src/test/java/org/ow2/mind/TestItfInheritance.java
+++ b/adl-backend/src/test/java/org/ow2/mind/TestItfInheritance.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2013 Schneider-Electric
+ *
+ * This file is part of "Mind Compiler" is free software: you can redistribute 
+ * it and/or modify it under the terms of the GNU Lesser General Public License 
+ * as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact: mind@ow2.org
+ *
+ * Authors: Stephane Seyvoz
+ * Contributors: 
+ */
+
+package org.ow2.mind;
+
+import org.testng.annotations.Test;
+
+public class TestItfInheritance extends AbstractFunctionalTest {
+
+  @Test(groups = {"checkin"})
+  public void testItfInheritance() throws Exception {
+    initSourcePath(getDepsDir("fractal/api/Component.itf").getAbsolutePath(),
+        "common", "functional");
+    runner.compileRunAndCheck("itfinheritance.HelloworldApplication", null);
+  }
+
+  @Test(groups = {"checkin"})
+  public void testCollectionItfInheritance() throws Exception {
+    initSourcePath(getDepsDir("fractal/api/Component.itf").getAbsolutePath(),
+        "common", "functional");
+    runner.compileRunAndCheck("itfinheritance.HelloworldApplicationCollection",
+        null);
+  }
+
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/Client.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/Client.adl
@@ -1,0 +1,7 @@
+primitive itfinheritance.Client {
+  
+  provides Main as main;
+  requires Service as sa ;
+  
+  source client.c;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/ClientCollection.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/ClientCollection.adl
@@ -1,0 +1,7 @@
+primitive itfinheritance.ClientCollection {
+  
+  provides Main as main;
+  requires Service as sa[2] ;
+  
+  source clientcollection.c;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/ExtendedService.itf
+++ b/adl-backend/src/test/resources/functional/itfinheritance/ExtendedService.itf
@@ -1,0 +1,7 @@
+
+interface itfinheritance.ExtendedService : itfinheritance.Service {
+
+  void resetCount(void);
+
+};
+

--- a/adl-backend/src/test/resources/functional/itfinheritance/Helloworld.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/Helloworld.adl
@@ -1,0 +1,10 @@
+@Run
+composite itfinheritance.Helloworld {
+  provides Main as main;
+
+  contains Client as client;
+  contains Server as server;
+  
+  binds this.main to client.main;
+  binds client.sa to server.s;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/HelloworldApplication.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/HelloworldApplication.adl
@@ -1,0 +1,4 @@
+@Run(addBootstrap=false)
+composite itfinheritance.HelloworldApplication 
+    extends GenericApplication<Helloworld> {
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/HelloworldApplicationCollection.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/HelloworldApplicationCollection.adl
@@ -1,0 +1,4 @@
+@Run(addBootstrap=false)
+composite itfinheritance.HelloworldApplicationCollection
+    extends GenericApplication<HelloworldCollection> {
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/HelloworldCollection.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/HelloworldCollection.adl
@@ -1,0 +1,12 @@
+@Run
+composite itfinheritance.HelloworldCollection {
+  provides Main as main;
+
+  contains ClientCollection as client;
+  contains ServerCollection as server;
+  
+  binds this.main to client.main;
+  
+  /* here the binding is a collection binding */
+  binds client.sa to server.s;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/Server.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/Server.adl
@@ -1,0 +1,9 @@
+@Singleton
+primitive itfinheritance.Server {
+  
+  provides ExtendedService as s ;
+  
+  attribute int count = 2;
+  
+  source server.c;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/ServerCollection.adl
+++ b/adl-backend/src/test/resources/functional/itfinheritance/ServerCollection.adl
@@ -1,0 +1,9 @@
+@Singleton
+primitive itfinheritance.ServerCollection {
+  
+  provides ExtendedService as s[2] ;
+  
+  attribute int count = 2;
+  
+  source servercollection.c;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/Service.itf
+++ b/adl-backend/src/test/resources/functional/itfinheritance/Service.itf
@@ -1,0 +1,11 @@
+
+interface itfinheritance.Service {
+
+  void print(const char *msg);
+ 
+  void println(const char *msg);
+  
+  void flush();
+
+};
+

--- a/adl-backend/src/test/resources/functional/itfinheritance/client.c
+++ b/adl-backend/src/test/resources/functional/itfinheritance/client.c
@@ -1,0 +1,17 @@
+
+/* -----------------------------------------------------------------------------
+   Implementation of the main interface.
+----------------------------------------------------------------------------- */
+
+/* int main(int argc, string[] argv) */
+int METH(main, main) (int argc, char *argv[]){
+
+  /* call the 'print' method of the 'sa' client interface. */
+  CALL(sa, print)("hello world");
+
+  /* call again the same method to look at invocation count */
+  CALL(sa, println)("hello world");
+
+
+  return 0;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/clientcollection.c
+++ b/adl-backend/src/test/resources/functional/itfinheritance/clientcollection.c
@@ -1,0 +1,22 @@
+
+/* -----------------------------------------------------------------------------
+   Implementation of the main interface.
+----------------------------------------------------------------------------- */
+
+/* int main(int argc, string[] argv) */
+int METH(main, main) (int argc, char *argv[]){
+
+	/* call the 'print' method of the 'sa' client interface. */
+	CALL(sa[0], print)("hello world");
+
+	/* call again the same method to look at invocation count */
+	CALL(sa[0], println)("hello world");
+
+	/* call the 'print' method of the 'sa' client interface. */
+	CALL(sa[1], print)("hello world");
+
+	/* call again the same method to look at invocation count */
+	CALL(sa[1], println)("hello world");
+
+	return 0;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/foo.h
+++ b/adl-backend/src/test/resources/functional/itfinheritance/foo.h
@@ -1,0 +1,9 @@
+#ifndef FOO_H
+#define FOO_H
+
+typedef struct {
+  int a, b;
+
+} foo;
+
+#endif

--- a/adl-backend/src/test/resources/functional/itfinheritance/server.c
+++ b/adl-backend/src/test/resources/functional/itfinheritance/server.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+
+/* -----------------------------------------------------------------------------
+   Implementation of the service interface.
+----------------------------------------------------------------------------- */
+
+/* void print(string msg) */
+void METH(s, print)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    printf("%s", msg);
+  }
+
+  printf("Server: print done\n");
+  CALL(s, flush)();
+}
+
+void METH(s, println)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    CALL(s, print)(msg);
+    CALL(s, print)("\n");
+  }
+
+  printf("Server: print done\n");
+}
+
+
+void METH(s, flush)(void)
+{
+  /* Nothing to do... */
+}
+
+void METH(s, resetCount)(void) {
+	ATTR(count) = 2;
+}

--- a/adl-backend/src/test/resources/functional/itfinheritance/servercollection.c
+++ b/adl-backend/src/test/resources/functional/itfinheritance/servercollection.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+
+/* -----------------------------------------------------------------------------
+   Implementation of the service interface.
+----------------------------------------------------------------------------- */
+
+//------------------------
+// Collection element 0
+//------------------------
+
+/* void print(string msg) */
+void METH(s[0], print)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    printf("%s", msg);
+  }
+
+  printf("Server: print done\n");
+  CALL(s[0], flush)();
+}
+
+void METH(s[0], println)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    CALL(s[0], print)(msg);
+    CALL(s[0], print)("\n");
+  }
+
+  printf("Server: print done\n");
+}
+
+
+void METH(s[0], flush)(void)
+{
+  /* Nothing to do... */
+}
+
+void METH(s[0], resetCount)(void) {
+	ATTR(count) = 2;
+}
+
+//------------------------
+// Collection element 1
+//------------------------
+
+/* void print(string msg) */
+void METH(s[1], print)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    printf("%s", msg);
+  }
+
+  printf("Server: print done\n");
+  CALL(s[1], flush)();
+}
+
+void METH(s[1], println)(const char *msg)
+{
+  int i;
+
+  printf("Server: begin printing...\n");
+  for (i = 0; i < ATTR(count); ++i) {
+    CALL(s[1], print)(msg);
+    CALL(s[1], print)("\n");
+  }
+
+  printf("Server: print done\n");
+}
+
+
+void METH(s[1], flush)(void)
+{
+  /* Nothing to do... */
+}
+
+void METH(s[1], resetCount)(void) {
+	ATTR(count) = 2;
+}


### PR DESCRIPTION
# Feature/bugfix

Bindings using type-hierarchy-related interfaces now have C cast generated where needed.
## Pre-requisite

Accepting Pull Requests https://github.com/MIND-Tools/mind-compiler/pull/8 and then https://github.com/MIND-Tools/mind-compiler/pull/11 (https://github.com/MIND-Tools/mind-compiler/pull/11 is already dependending on https://github.com/MIND-Tools/mind-compiler/pull/8) ; contribution should then be reduced to commit b3dde39fde713d4c63fd778c4c30ee7e822a70db
## Issue description

C compilers raise a warning on pointer casts when trying to initialize a binding from an I1 interface type struct pointer with an I2 destination interface struct, where I2 extends I1.
## Solution

Detection on binding check and tag the according AST interface/binding nodes to add the necessary cast with StringTemplates.
