### PR TITLE
Ccs compiler assembly extension support

### DIFF
--- a/adl-frontend/src/main/java/org/ow2/mind/adl/ast/ASTHelper.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/ast/ASTHelper.java
@@ -703,7 +703,8 @@ public class ASTHelper {
     final String srcPath = src.getPath();
     if (srcPath == null) return false;
     final String srcExt = PathHelper.getExtension(srcPath);
-    return srcExt != null && (srcExt.equals("s") || srcExt.equals("S"));
+    return srcExt != null
+        && (srcExt.equals("s") || srcExt.equals("S") || srcExt.equals("asm"));
   }
 
   /**


### PR DESCRIPTION
Support of '.asm' files extension for TI's Code Composer Studio compiler (doesn't accept .s/.S, only .asm).
