### PR TITLE
[fix_jira_144] Missing Methods detection test fix

### DIFF
--- a/cpl-preproc/src/main/java/org/ow2/mind/preproc/ImplementedMethodsHelper.java
+++ b/cpl-preproc/src/main/java/org/ow2/mind/preproc/ImplementedMethodsHelper.java
@@ -29,9 +29,9 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.objectweb.fractal.adl.ADLException;
 import org.objectweb.fractal.adl.Definition;
@@ -173,7 +173,7 @@ public class ImplementedMethodsHelper {
 
     final int nbElement = getNumberOfElement(itf);
     final Map<Integer, List<String>> implMeths = getCollectionImplementedMethods(itf);
-    final Map<Integer, List<String>> result = new HashMap<Integer, List<String>>();
+    final Map<Integer, List<String>> result = new TreeMap<Integer, List<String>>();
 
     InterfaceDefinition itfDef;
 
@@ -250,7 +250,7 @@ public class ImplementedMethodsHelper {
 
     final Map<Integer, List<String>> idxMethNamesMap = (Map<Integer, List<String>>) itf
         .astGetDecoration(IMPLEMENTED_METHODS);
-    if (idxMethNamesMap == null) return new HashMap<Integer, List<String>>();
+    if (idxMethNamesMap == null) return new TreeMap<Integer, List<String>>();
 
     return idxMethNamesMap;
   }


### PR DESCRIPTION
HashMap -> TreeMap in ImplementedMethodsHelper for consistent collection index order in the keySet, since TreeMap uses the natural order for its keys by default (whereas HashMap doesn't).

This should fix the TestMissingMethodsError#testCollMissingPrintLnFlushX2 error in the adl-backend.

Bug happening with Bamboo, expecting error on s[0], but happening with s[1], since HashMap
keySet are not ordered. The Map is used in CPLChecker#postParseChecks by getting the keySet, transforming it as an Array, and getting its first element. However the Map was created in the ImplementedMethodsHelper, hence this commit.
