### PR TITLE
Make ASFlags, CFlags, CPPFlags, LDFlags inheritable.

### DIFF
--- a/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/ASFlags.java
+++ b/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/ASFlags.java
@@ -54,6 +54,6 @@ public class ASFlags implements Annotation {
   }
 
   public boolean isInherited() {
-    return false;
+    return true;
   }
 }

--- a/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/CFlags.java
+++ b/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/CFlags.java
@@ -54,6 +54,6 @@ public class CFlags implements Annotation {
   }
 
   public boolean isInherited() {
-    return false;
+    return true;
   }
 }

--- a/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/CPPFlags.java
+++ b/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/CPPFlags.java
@@ -54,6 +54,6 @@ public class CPPFlags implements Annotation {
   }
 
   public boolean isInherited() {
-    return false;
+    return true;
   }
 }

--- a/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/LDFlags.java
+++ b/adl-backend/src/main/java/org/ow2/mind/adl/annotation/predefined/LDFlags.java
@@ -47,6 +47,6 @@ public class LDFlags implements Annotation {
   }
 
   public boolean isInherited() {
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
Today, the annotations are not propagated to children types, needing unwanted duplication.

Note: The annotation system, when using inheritance, is already made to override with the children one, as coded in common-frontend/src/main/java/org.ow2.mind.annotation/AnnotationHelper.java#mergeDecoration method.
