### PR TITLE
Propagating the desired execName (binary output name) for all phases.

### DIFF
--- a/mindc/src/main/java/org/ow2/mind/BasicADLCompiler.java
+++ b/mindc/src/main/java/org/ow2/mind/BasicADLCompiler.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010 STMicroelectronics
+ * Copyright (C) 2014 Schneider-Electric
  *
  * This file is part of "Mind Compiler" is free software: you can redistribute 
  * it and/or modify it under the terms of the GNU Lesser General Public License 
@@ -17,7 +18,7 @@
  * Contact: mind@ow2.org
  *
  * Authors: Matthieu Leclercq
- * Contributors: 
+ * Contributors: Stephane Seyvoz
  */
 
 package org.ow2.mind;
@@ -44,7 +45,9 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 /**
- * Basic implementation of {@link ADLCompiler} interface.
+ * Basic implementation of {@link ADLCompiler} interface. Contribution: Moved
+ * the executable name context setting from compileGraph to initContext, to
+ * allow earlier access from plugins.
  */
 public class BasicADLCompiler extends AbstractADLCompiler {
 
@@ -66,12 +69,21 @@ public class BasicADLCompiler extends AbstractADLCompiler {
       final CompilationStage stage, final Map<Object, Object> context)
       throws ADLException {
 
-    /**
-     * Some plugins may need the executable name earlier than the compileGraph
-     * (see below), for example as early as the check-adl phase.
-     */
     if (execName != null) {
       CompilerContextHelper.setExecutableName(context, execName);
+    } else {
+      final String targetDescName = TargetDescriptorOptionHandler
+          .getTargetDescriptor(context);
+      if (targetDescName != null) {
+        final Target target = targetDescriptorLoader.load(targetDescName,
+            context);
+        final ADLMapping adlMapping = target.getAdlMapping();
+        if (adlMapping != null && adlMapping.getOutputName() != null) {
+          final String tdExecName = adlMapping.getMapping().replace(
+              "${inputADL}", adlName);
+          CompilerContextHelper.setExecutableName(context, tdExecName);
+        }
+      }
     }
 
   }
@@ -115,22 +127,7 @@ public class BasicADLCompiler extends AbstractADLCompiler {
   @Override
   protected Collection<CompilationCommand> compileGraph(
       final Map<Object, Object> context, final ComponentGraph graph,
-      String execName) throws ADLException {
-    if (execName != null) {
-      CompilerContextHelper.setExecutableName(context, execName);
-    } else {
-      final String targetDescName = TargetDescriptorOptionHandler
-          .getTargetDescriptor(context);
-      if (targetDescName != null) {
-        final Target target = targetDescriptorLoader.load(targetDescName,
-            context);
-        final ADLMapping adlMapping = target.getAdlMapping();
-        if (adlMapping != null && adlMapping.getOutputName() != null) {
-          execName = adlMapping.getMapping().replace("${inputADL}",
-              graph.getDefinition().getName());
-        }
-      }
-    }
+      final String execName) throws ADLException {
 
     return graphCompiler.visit(graph, context);
   }


### PR DESCRIPTION
The desired execName (user-provided binary output name) was not available for all phases, only during "compileGraph", calling the backend.
We needed it for an annotation plugin, which annotation processor is executed the Loaders "check-adl" phase.

Original behaviour:
- mindc/src/main/java/org.ow2.mind.AbstractADLCompiler#compile:119 called BasicADLCompiler#compileGraph which did: CompilerContextHelper.setExecutableName(context, execName);

Proposition:
- mindc/src/main/java/org.ow2.mind.AbstractADLCompiler#compile:74 calling BasicADLCompiler#initContext, doing the same, but earlier.

Note: I saw that our proposition is redundant with compileGraph (cleanup ?), and doesn't seem to handle the Target Descriptor case (contrary to the compileGraph method), however the latter seems non-functional since it computes an unused execName value, anyway. What do you think ?
