### PR TITLE
[fix_jira_143] Use new version of mind-parent (7-SNAPSHOT).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
-install: mvn -U clean -PCI-profile
-script: mvn -U verify -PCI-profile
+before_install:
+  - "git clone https://github.com/MIND-Tools/maven.git"
+  - "cd maven/mind-parent"
+  - "mvn -U install"
+  - "cd ../.."    
+install: 
+  - "mvn -U clean -PCI-profile"
+script: 
+  - "mvn -U verify -PCI-profile"

--- a/adl-backend/pom.xml
+++ b/adl-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>adl-backend</artifactId>
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
 
         <dependency>

--- a/adl-frontend/pom.xml
+++ b/adl-frontend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>adl-frontend</artifactId>
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
 
         <dependency>

--- a/adl-parser/pom.xml
+++ b/adl-parser/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>adl-parser</artifactId>
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>annotations</artifactId>
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
 
         <dependency>

--- a/common-backend/pom.xml
+++ b/common-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-backend</artifactId>
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/common-frontend/pom.xml
+++ b/common-frontend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-frontend</artifactId>
@@ -55,10 +55,9 @@
         </dependency>
 
         <dependency>
-		    <groupId>org.testng</groupId>
-		    <artifactId>testng</artifactId>
-		    <classifier>jdk15</classifier>
-	    </dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cpl-preproc/pom.xml
+++ b/cpl-preproc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cpl-preproc</artifactId>
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
         <dependency>
         	<groupId>${project.groupId}</groupId>

--- a/fractal-adl-bundle/pom.xml
+++ b/fractal-adl-bundle/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.ow2.mind</groupId>
 		<artifactId>mind-compiler</artifactId>
-		<version>2.1-SNAPSHOT</version>
+		<version>2.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>fractal-adl-bundle</artifactId>

--- a/fractal-runtime/pom.xml
+++ b/fractal-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>fractal-runtime</artifactId>
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/idl-backend/pom.xml
+++ b/idl-backend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>idl-backend</artifactId>
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/idl-frontend/pom.xml
+++ b/idl-frontend/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>idl-frontend</artifactId>
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
 
         <dependency>

--- a/idl-parser/pom.xml
+++ b/idl-parser/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>idl-parser</artifactId>
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 

--- a/mindc/pom.xml
+++ b/mindc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mindc</artifactId>
@@ -44,10 +44,9 @@
         </dependency>
 
         <dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<classifier>jdk15</classifier>
-		</dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mindc/src/assemble/bin-release.xml
+++ b/mindc/src/assemble/bin-release.xml
@@ -37,6 +37,7 @@
                 <include>${project.groupId}:fractal-runtime</include>
             </includes>
             <outputDirectory>runtime</outputDirectory>
+            <directoryMode>0755</directoryMode>
             <fileMode>0644</fileMode>
         </dependencySet>
 

--- a/plugin-loader/pom.xml
+++ b/plugin-loader/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-compiler</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>plugin-loader</artifactId>
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.ow2.mind</groupId>
         <artifactId>mind-parent</artifactId>
-        <version>6</version>
+        <version>7-SNAPSHOT</version>
     </parent>
 
     <artifactId>mind-compiler</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
     <name>Mind compiler</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
```
Changed mind-compiler version from 2.1-SNAPSHOT to 2.2-SNAPSHOT.
Modified .travis.yml to build mind-parent 7-SNAPSHOT before validation.
Removed testng classifier markers in pom.xml files.
Changed access rights on fractal-runtime output directory.
```
