### PR TITLE
New include flags handling (more generic) + Debug-friendly commands

### DIFF
--- a/adl-backend/src/main/java/org/ow2/mind/adl/compilation/ContextFlagsCompilationCommandFactory.java
+++ b/adl-backend/src/main/java/org/ow2/mind/adl/compilation/ContextFlagsCompilationCommandFactory.java
@@ -63,6 +63,9 @@ public class ContextFlagsCompilationCommandFactory
         context);
 
     command.addFlags(CompilerContextHelper.getCPPFlags(context));
+    for (final String inc : CompilerContextHelper.getIncPath(context)) {
+      command.addIncludeDir(new File(inc));
+    }
     command.addFlags(CompilerContextHelper.getCFlags(context));
 
     command.addIncludeDir(outputFileLocatorItf.getCSourceOutputDir(context));
@@ -106,6 +109,9 @@ public class ContextFlagsCompilationCommandFactory
 
     if (!preprocessedFile) {
       command.addFlags(CompilerContextHelper.getCPPFlags(context));
+    }
+    for (final String inc : CompilerContextHelper.getIncPath(context)) {
+      command.addIncludeDir(new File(inc));
     }
     command.addFlags(CompilerContextHelper.getCFlags(context));
 

--- a/common-backend/src/main/java/org/ow2/mind/compilation/AbstractAssemblerCommand.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/AbstractAssemblerCommand.java
@@ -33,7 +33,11 @@ public abstract class AbstractAssemblerCommand implements AssemblerCommand {
 
   protected final Map<Object, Object> context;
   protected String                    cmd;
+  protected String                    fullCmd;
   protected final List<String>        flags             = new ArrayList<String>();
+  protected final List<String>        defines           = new ArrayList<String>();
+  protected final List<File>          includeDir        = new ArrayList<File>();
+  protected final List<File>          includeFile       = new ArrayList<File>();
   protected File                      inputFile;
   protected File                      outputFile;
   protected File                      dependencyOutputFile;
@@ -79,6 +83,24 @@ public abstract class AbstractAssemblerCommand implements AssemblerCommand {
 
   public AssemblerCommand addDefine(final String name) {
     return addDefine(name, null);
+  }
+
+  public AssemblerCommand addDefine(final String name, final String value) {
+    if (value != null)
+      defines.add(name + "=" + value);
+    else
+      defines.add(name);
+    return this;
+  }
+
+  public AssemblerCommand addIncludeDir(final File incDir) {
+    includeDir.add(incDir);
+    return this;
+  }
+
+  public AssemblerCommand addIncludeFile(final File incFile) {
+    includeFile.add(incFile);
+    return this;
   }
 
   public AssemblerCommand setInputFile(final File inputFile) {

--- a/common-backend/src/main/java/org/ow2/mind/compilation/AbstractCompilerCommand.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/AbstractCompilerCommand.java
@@ -33,7 +33,11 @@ public abstract class AbstractCompilerCommand implements CompilerCommand {
 
   protected final Map<Object, Object> context;
   protected String                    cmd;
+  protected String                    fullCmd;
   protected final List<String>        flags             = new ArrayList<String>();
+  protected final List<String>        defines           = new ArrayList<String>();
+  protected final List<File>          includeDir        = new ArrayList<File>();
+  protected final List<File>          includeFile       = new ArrayList<File>();
   protected File                      inputFile;
   protected File                      outputFile;
   protected File                      dependencyOutputFile;
@@ -79,6 +83,24 @@ public abstract class AbstractCompilerCommand implements CompilerCommand {
 
   public CompilerCommand addDefine(final String name) {
     return addDefine(name, null);
+  }
+
+  public CompilerCommand addDefine(final String name, final String value) {
+    if (value != null)
+      defines.add(name + "=" + value);
+    else
+      defines.add(name);
+    return this;
+  }
+
+  public CompilerCommand addIncludeDir(final File incDir) {
+    includeDir.add(incDir);
+    return this;
+  }
+
+  public CompilerCommand addIncludeFile(final File incFile) {
+    includeFile.add(incFile);
+    return this;
   }
 
   public CompilerCommand setInputFile(final File inputFile) {
@@ -156,6 +178,12 @@ public abstract class AbstractCompilerCommand implements CompilerCommand {
         forced = true;
       }
     }
+
+    /*
+     * In order for macros and header files to be ready in any case at compile
+     * time (needed for inline cases otherwise scheduling breaks)
+     */
+    if (includeFile != null) inputFiles.addAll(includeFile);
 
     if (dependencyOutputFile != null)
       outputFiles = Arrays.asList(outputFile, dependencyOutputFile);

--- a/common-backend/src/main/java/org/ow2/mind/compilation/AbstractLinkerCommand.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/AbstractLinkerCommand.java
@@ -33,6 +33,7 @@ public abstract class AbstractLinkerCommand implements LinkerCommand {
 
   protected final Map<Object, Object> context;
   protected String                    cmd;
+  protected String                    fullCmd;
   protected final List<String>        flags      = new ArrayList<String>();
   protected final List<File>          inputFiles = new ArrayList<File>();
   protected final List<String>        libs       = new ArrayList<String>();

--- a/common-backend/src/main/java/org/ow2/mind/compilation/AbstractPreprocessorCommand.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/AbstractPreprocessorCommand.java
@@ -35,7 +35,11 @@ public abstract class AbstractPreprocessorCommand
 
   protected final Map<Object, Object> context;
   protected String                    cmd;
+  protected String                    fullCmd;
   protected final List<String>        flags             = new ArrayList<String>();
+  protected final List<String>        defines           = new ArrayList<String>();
+  protected final List<File>          includeDir        = new ArrayList<File>();
+  protected final List<File>          includeFile       = new ArrayList<File>();
   protected File                      inputFile;
   protected File                      outputFile;
   protected File                      dependencyOutputFile;
@@ -82,8 +86,26 @@ public abstract class AbstractPreprocessorCommand
     return addDefine(name, null);
   }
 
-  public PreprocessorCommand setInputFile(final File inputFile) {
-    this.inputFile = inputFile;
+  public PreprocessorCommand addDefine(final String name, final String value) {
+    if (value != null)
+      defines.add(name + "=" + value);
+    else
+      defines.add(name);
+    return this;
+  }
+
+  public PreprocessorCommand addIncludeDir(final File incDir) {
+    includeDir.add(incDir);
+    return this;
+  }
+
+  public PreprocessorCommand addIncludeFile(final File incFile) {
+    includeFile.add(incFile);
+    return this;
+  }
+
+  public PreprocessorCommand setInputFile(final File inFile) {
+    inputFile = inFile;
     return this;
   }
 
@@ -91,8 +113,8 @@ public abstract class AbstractPreprocessorCommand
     return inputFile;
   }
 
-  public PreprocessorCommand setOutputFile(final File outputFile) {
-    this.outputFile = outputFile;
+  public PreprocessorCommand setOutputFile(final File outFile) {
+    outputFile = outFile;
     return this;
   }
 

--- a/common-backend/src/main/java/org/ow2/mind/compilation/CompilerContextHelper.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/CompilerContextHelper.java
@@ -38,6 +38,7 @@ public final class CompilerContextHelper {
   public static final String EXECUTABLE_NAME_CONTEXT_KEY   = "executable-name";
 
   public static final String C_FLAGS_CONTEXT_KEY           = "c-flags";
+  public static final String INC_PATH_CONTEXT_KEY          = "inc-path";
   public static final String AS_FLAGS_CONTEXT_KEY          = "as-flags";
   public static final String CPP_FLAGS_CONTEXT_KEY         = "cpp-flags";
   public static final String LD_FLAGS_CONTEXT_KEY          = "ld-flags";
@@ -90,6 +91,28 @@ public final class CompilerContextHelper {
     return flags;
   }
 
+  public static void setIncPath(final Map<Object, Object> context,
+      final List<String> inc) {
+    context.put(INC_PATH_CONTEXT_KEY, inc);
+  }
+
+  public static void addIncPath(final Map<Object, Object> context,
+      final List<String> inc) {
+    final List<String> i = getCFlags(context);
+    if (i.isEmpty()) {
+      setCFlags(context, inc);
+    } else {
+      i.addAll(inc);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<String> getIncPath(final Map<Object, Object> context) {
+    List<String> inc = (List<String>) context.get(INC_PATH_CONTEXT_KEY);
+    if (inc == null) inc = Collections.emptyList();
+    return inc;
+  }
+
   public static void setASFlags(final Map<Object, Object> context,
       final List<String> flags) {
     context.put(AS_FLAGS_CONTEXT_KEY, flags);
@@ -105,6 +128,7 @@ public final class CompilerContextHelper {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static List<String> getASFlags(final Map<Object, Object> context) {
     List<String> flags = (List<String>) context.get(AS_FLAGS_CONTEXT_KEY);
     if (flags == null) flags = Collections.emptyList();
@@ -126,6 +150,7 @@ public final class CompilerContextHelper {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static List<String> getLDFlags(final Map<Object, Object> context) {
     List<String> flags = (List<String>) context.get(LD_FLAGS_CONTEXT_KEY);
     if (flags == null) flags = Collections.emptyList();

--- a/common-backend/src/main/java/org/ow2/mind/compilation/gcc/GccCompilerWrapper.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/gcc/GccCompilerWrapper.java
@@ -98,25 +98,6 @@ public class GccCompilerWrapper implements CompilerWrapper {
       return this;
     }
 
-    public PreprocessorCommand addDefine(final String name, final String value) {
-      if (value != null)
-        flags.add("-D" + name + "=" + value);
-      else
-        flags.add("-D" + name);
-      return this;
-    }
-
-    public PreprocessorCommand addIncludeDir(final File includeDir) {
-      flags.add("-I" + includeDir.getPath());
-      return this;
-    }
-
-    public PreprocessorCommand addIncludeFile(final File includeFile) {
-      flags.add("-include");
-      flags.add(includeFile.getPath());
-      return this;
-    }
-
     @Override
     protected Collection<File> readDependencies() {
       return readDeps(dependencyOutputFile, outputFile, context);
@@ -128,6 +109,19 @@ public class GccCompilerWrapper implements CompilerWrapper {
       cmd.add("-E");
 
       cmd.addAll(flags);
+
+      for (final String def : defines) {
+        cmd.add("-D" + def);
+      }
+
+      for (final File incDir : includeDir) {
+        cmd.add("-I" + incDir.getPath().trim());
+      }
+
+      for (final File incFile : includeFile) {
+        cmd.add("-include");
+        cmd.add(incFile.getPath());
+      }
 
       if (dependencyOutputFile != null) {
         cmd.add("-MMD");
@@ -141,6 +135,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
       cmd.add(outputFile.getPath());
 
       cmd.add(inputFile.getPath());
+
+      // save full command for debug and log purposes
+      final StringBuilder sb = new StringBuilder();
+      for (final String str : cmd) {
+        sb.append(str);
+        sb.append(" ");
+      }
+      fullCmd = sb.toString();
 
       // execute command
       ExecutionResult result;
@@ -170,6 +172,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
     public String getDescription() {
       return "CPP: " + outputFile.getPath();
     }
+
+    @Override
+    public String toString() {
+      if (fullCmd == null)
+        return super.toString();
+      else
+        return fullCmd;
+    }
   }
 
   protected class GccCompilerCommand extends AbstractCompilerCommand {
@@ -180,25 +190,6 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
     public CompilerCommand addDebugFlag() {
       flags.add("-g");
-      return this;
-    }
-
-    public CompilerCommand addDefine(final String name, final String value) {
-      if (value != null)
-        flags.add("-D" + name + "=" + value);
-      else
-        flags.add("-D" + name);
-      return this;
-    }
-
-    public CompilerCommand addIncludeDir(final File includeDir) {
-      flags.add("-I" + includeDir.getPath());
-      return this;
-    }
-
-    public CompilerCommand addIncludeFile(final File includeFile) {
-      flags.add("-include");
-      flags.add(includeFile.getPath());
       return this;
     }
 
@@ -215,6 +206,18 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
       cmd.addAll(flags);
 
+      for (final String def : defines) {
+        cmd.add("-D" + def);
+      }
+      for (final File incDir : includeDir) {
+        cmd.add("-I" + incDir.getPath().trim());
+      }
+
+      for (final File incFile : includeFile) {
+        cmd.add("-include");
+        cmd.add(incFile.getPath());
+      }
+
       if (dependencyOutputFile != null) {
         cmd.add("-MMD");
         cmd.add("-MF");
@@ -227,6 +230,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
       cmd.add(outputFile.getPath());
 
       cmd.add(inputFile.getPath());
+
+      // save full command for debug and log purposes
+      final StringBuilder sb = new StringBuilder();
+      for (final String str : cmd) {
+        sb.append(str);
+        sb.append(" ");
+      }
+      fullCmd = sb.toString();
 
       // execute command
       ExecutionResult result;
@@ -257,6 +268,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
       return "GCC: " + outputFile.getPath();
 
     }
+
+    @Override
+    public String toString() {
+      if (fullCmd == null)
+        return super.toString();
+      else
+        return fullCmd;
+    }
   }
 
   protected class GccAssemblerCommand extends AbstractAssemblerCommand {
@@ -267,25 +286,6 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
     public AssemblerCommand addDebugFlag() {
       flags.add("-g");
-      return this;
-    }
-
-    public AssemblerCommand addDefine(final String name, final String value) {
-      if (value != null)
-        flags.add("-D" + name + "=" + value);
-      else
-        flags.add("-D" + name);
-      return this;
-    }
-
-    public AssemblerCommand addIncludeDir(final File includeDir) {
-      flags.add("-I" + includeDir.getPath().trim());
-      return this;
-    }
-
-    public AssemblerCommand addIncludeFile(final File includeFile) {
-      flags.add("-include");
-      flags.add(includeFile.getPath());
       return this;
     }
 
@@ -302,10 +302,29 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
       cmd.addAll(flags);
 
+      for (final String def : defines) {
+        cmd.add("-D" + def);
+      }
+      for (final File incDir : includeDir) {
+        cmd.add("-I" + incDir.getPath().trim());
+      }
+
+      for (final File incFile : includeFile) {
+        cmd.add("-include");
+        cmd.add(incFile.getPath());
+      }
       cmd.add("-o");
       cmd.add(outputFile.getPath());
 
       cmd.add(inputFile.getPath());
+
+      // save full command for debug and log purposes
+      final StringBuilder sb = new StringBuilder();
+      for (final String str : cmd) {
+        sb.append(str);
+        sb.append(" ");
+      }
+      fullCmd = sb.toString();
 
       // execute command
       ExecutionResult result;
@@ -334,33 +353,12 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
     }
 
-    /*
-     * SSZ: Here we abuse the toString standard method to return a
-     * Makefile-compatible String. This String is the command ran by the exec()
-     * method (see above) (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-      final List<String> cmd = new ArrayList<String>();
-      cmd.add(this.cmd);
-      cmd.add("-c");
-
-      cmd.addAll(flags);
-
-      cmd.add("-o");
-      cmd.add(outputFile.getPath());
-
-      cmd.add(inputFile.getPath());
-
-      // Build the final String from List<String>
-      final StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < cmd.size(); i++) {
-        sb.append(cmd.get(i));
-        if (i < cmd.size() - 1) sb.append(" ");
-      }
-
-      return outputFile.getName() + ":\n\t" + sb.toString();
+      if (fullCmd == null)
+        return super.toString();
+      else
+        return fullCmd;
     }
   }
 
@@ -407,6 +405,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
       cmd.addAll(flags);
 
+      // save full command for debug and log purposes
+      final StringBuilder sb = new StringBuilder();
+      for (final String str : cmd) {
+        sb.append(str);
+        sb.append(" ");
+      }
+      fullCmd = sb.toString();
+
       // execute command
       ExecutionResult result;
       try {
@@ -431,6 +437,14 @@ public class GccCompilerWrapper implements CompilerWrapper {
 
     public String getDescription() {
       return "LD : " + outputFile.getPath();
+    }
+
+    @Override
+    public String toString() {
+      if (fullCmd == null)
+        return super.toString();
+      else
+        return fullCmd;
     }
   }
 

--- a/mindc/src/main/java/org/ow2/mind/cli/CmdAppendOption.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/CmdAppendOption.java
@@ -51,7 +51,7 @@ public class CmdAppendOption extends CmdArgument {
   }
 
   @Override
-  void setValue(final CommandLine commandLine, final String value)
+  public void setValue(final CommandLine commandLine, final String value)
       throws InvalidCommandLineException {
     if (value == null) return;
     final String prevValue = (String) commandLine.getOptionValue(this);

--- a/mindc/src/main/java/org/ow2/mind/cli/CmdArgument.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/CmdArgument.java
@@ -55,7 +55,7 @@ public class CmdArgument extends CmdOption {
     this(id, shortName, longName, description, argDesc, null, false);
   }
 
-  void setValue(final CommandLine commandLine, final String value)
+  public void setValue(final CommandLine commandLine, final String value)
       throws InvalidCommandLineException {
     if (value == null) return;
     final Object prevValue = commandLine.setOptionValue(this, value);
@@ -96,6 +96,10 @@ public class CmdArgument extends CmdOption {
       desc = "--" + longName + "=" + argDesc;
     }
     return desc;
+  }
+
+  public String getArgDescription() {
+    return argDesc;
   }
 
   @Override

--- a/mindc/src/main/java/org/ow2/mind/cli/FlagsOptionHandler.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/FlagsOptionHandler.java
@@ -100,7 +100,8 @@ public class FlagsOptionHandler implements CommandOptionHandler {
       final CmdPathOption includePathOpt = Assert.assertInstanceof(cmdOption,
           CmdPathOption.class);
 
-      final List<String> incPaths = new ArrayList<String>();
+      final List<String> incPaths = new ArrayList<String>(
+          CompilerContextHelper.getIncPath(context));
 
       // "src-path" is added as "inc-path"
       final CmdPathOption srcPathOpt = (CmdPathOption) cmdLine.getOptions()
@@ -113,17 +114,7 @@ public class FlagsOptionHandler implements CommandOptionHandler {
       }
       // "out-path is added as "inc-path"
       incPaths.add(OutPathOptionHandler.getOutPath(context).getAbsolutePath());
-
-      final List<String> cFlagsList = new ArrayList<String>(
-          CompilerContextHelper.getCFlags(context));
-
-      for (final String inc : incPaths) {
-        final File incDir = new File(inc);
-        cFlagsList.add("-I");
-        cFlagsList.add(incDir.getAbsolutePath());
-      }
-
-      CompilerContextHelper.setCPPFlags(context, cFlagsList);
+      CompilerContextHelper.setIncPath(context, incPaths);
 
     } else if (LDFLAGS_ID.equals(cmdOption.getId())) {
       // process LDFlags


### PR DESCRIPTION
#New include flags handling (more generic) + Debug-friendly commands

This contribution mostly moves the include flags and include directories handling from the "GccCompilerWrapper" to the Abstract Commands classes. This enables new compiler plugins to override the behaviour or include flags/paths syntax more easily, while benefiting the same basic functionalities where needed.

The contribution does the same concerning the Commands debug information via the new "toString" implementation.

Additional content include : 
- New "getIncPath" and "setIncPath" methods in the CompilerContextHelper
- A method access rights fix