### PR TITLE
Fixing parent attributes use in anonymous sub-components

### DIFF
--- a/adl-backend/src/test/java/org/ow2/mind/FunctionalTest.java
+++ b/adl-backend/src/test/java/org/ow2/mind/FunctionalTest.java
@@ -79,5 +79,4 @@ public class FunctionalTest extends AbstractFunctionalTest {
       assertEquals(r, runAnno.expectedResult, "Unexpected return value");
     }
   }
-
 }

--- a/adl-backend/src/test/resources/functional/attr/anon/ParametricComposite.adl
+++ b/adl-backend/src/test/resources/functional/attr/anon/ParametricComposite.adl
@@ -1,0 +1,21 @@
+/**
+ * Testing argument propagation.
+ * See mindc documentation 2.21 example and its description.
+ */
+composite attr.anon.ParametricComposite(compositeValue) extends ApplicationType {
+	
+	contains ApplicationType as implementation primitive {
+		
+		attribute int primitiveValue = compositeValue;
+		
+		source {{
+			#include <stdio.h>
+			int METH(main, main)(int argc, char **argv) {
+				return ATTR(primitiveValue) - 2;
+			}
+		}};
+	};
+	
+	binds this.main to implementation.main;
+	
+}

--- a/adl-backend/src/test/resources/functional/attr/anon/ParametricComposite2.adl
+++ b/adl-backend/src/test/resources/functional/attr/anon/ParametricComposite2.adl
@@ -1,0 +1,5 @@
+@Run
+composite attr.anon.ParametricComposite2 extends ApplicationType {
+	contains ParametricComposite(2) as subComp;
+	binds this.main to subComp.main;
+}

--- a/adl-frontend/src/main/java/org/ow2/mind/adl/graph/AttributeInstantiator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/graph/AttributeInstantiator.java
@@ -136,6 +136,20 @@ public class AttributeInstantiator extends AbstractDelegatingInstantiator {
 // } else {
 // refValues.put(refArgument.getName(), refValue);
 // }
+
+              // when the definition is anonymous, there are no written
+// arguments,
+              // only inferred ones and we've got only their name, no value...
+              // so we try to get the value from the parent context
+              if (subGraph.getDefinition().astGetType()
+                  .equals("anonymousDefinition")) {
+                final ValueContext parentValueContextByArgName = argumentValues
+                    .get(refArgument.getName());
+
+                if (parentValueContextByArgName != null)
+                  refArgument.setValue(parentValueContextByArgName.value);
+              }
+
               refValues.put(refArgument.getName(),
                   new ValueContext(refArgument.getValue(), argumentValues));
             }

--- a/adl-frontend/src/main/java/org/ow2/mind/adl/graph/AttributeInstantiator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/graph/AttributeInstantiator.java
@@ -138,9 +138,8 @@ public class AttributeInstantiator extends AbstractDelegatingInstantiator {
 // }
 
               // when the definition is anonymous, there are no written
-// arguments,
-              // only inferred ones and we've got only their name, no value...
-              // so we try to get the value from the parent context
+              // arguments, only inferred ones and we've got only their name,
+              // no value... so we try to get the value from the parent context
               if (subGraph.getDefinition().astGetType()
                   .equals("anonymousDefinition")) {
                 final ValueContext parentValueContextByArgName = argumentValues


### PR DESCRIPTION
See documentation example 2.21, that didn't work but does now.
http://mind.ow2.org/mindc/mindc-user-guide.html#d4e559

Comes with a non-regression test.