### PR TITLE
Fix search scope of FormalParameter-s resolution for generic definitions

### DIFF
--- a/adl-frontend/src/main/java/org/ow2/mind/adl/generic/TemplateInstantiatorImpl.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/generic/TemplateInstantiatorImpl.java
@@ -70,7 +70,7 @@ public class TemplateInstantiatorImpl implements TemplateInstantiator {
           final DefinitionReference defRef = subComp.getDefinitionReference();
 
           final Definition d = instantiateDefinitionReference(defRef,
-              typeArgumentValues, context);
+              templateInstance, typeArgumentValues, context);
           setResolvedComponentDefinition(subComp, d);
 
           if (isPartiallyInstantiatedTemplate(d))
@@ -125,7 +125,7 @@ public class TemplateInstantiatorImpl implements TemplateInstantiator {
   }
 
   protected Definition instantiateDefinitionReference(
-      final DefinitionReference defRef,
+      final DefinitionReference defRef, final Definition templateInstance,
       final Map<String, Object> typeArgumentValues,
       final Map<Object, Object> context) throws ADLException {
 
@@ -138,8 +138,8 @@ public class TemplateInstantiatorImpl implements TemplateInstantiator {
       unsetResolvedDefinition(defRef);
     }
 
-    final Definition d = definitionReferenceResolverItf.resolve(defRef, null,
-        context);
+    final Definition d = definitionReferenceResolverItf.resolve(defRef,
+        templateInstance, context);
 
     return d;
   }

--- a/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite3.adl
+++ b/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite3.adl
@@ -1,0 +1,11 @@
+
+import pkg1.pkg2.Primitive1;
+import pkg1.pkg2.Type1;
+
+composite pkg1.parameterGeneric.Composite3 extends Type1 {
+
+	contains Composite4<Primitive1>(10) as c1;
+
+	binds this.sItf to c1.sItf;
+	binds c1.cItf to this.cItf;
+}

--- a/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite4.adl
+++ b/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite4.adl
@@ -1,0 +1,10 @@
+
+import pkg1.pkg2.Type1;
+
+composite pkg1.parameterGeneric.Composite4<Comp conformsto Type1>(a) extends Type1 {
+
+	contains Composite5<Comp>(a) as c1;
+
+	binds this.sItf to c1.sItf;
+	binds c1.cItf to this.cItf;
+}

--- a/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite5.adl
+++ b/adl-frontend/src/test/resources/pkg1/parameterGeneric/Composite5.adl
@@ -1,0 +1,13 @@
+
+import pkg1.pkg2.Type1;
+import pkg1.pkg2.Primitive3;
+
+composite pkg1.parameterGeneric.Composite5<aComp conformsto Type1>(a) extends Type1 {
+
+	contains aComp as c1;
+	contains Primitive3(a) as c2;
+
+	binds this.sItf to c1.sItf;
+	binds c1.cItf to this.cItf;
+	binds c2.cItf to this.cItf;
+}

--- a/adl-frontend/src/test/resources/pkg1/pkg2/Primitive3.adl
+++ b/adl-frontend/src/test/resources/pkg1/pkg2/Primitive3.adl
@@ -1,0 +1,6 @@
+
+primitive pkg1.pkg2.Primitive3(a) extends Type1 {
+
+  source {{ }};
+  attribute int attr1 = a;
+}


### PR DESCRIPTION
Argument propagation used to be broken for generic definition: The encapsulatingDefinition for formal parameter resolution was null for templates, instead of the real parent composite.