### PR TITLE
Maven support

### DIFF
--- a/adl-frontend/src/main/java/org/ow2/mind/adl/BasicADLLocator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/BasicADLLocator.java
@@ -87,15 +87,22 @@ public class BasicADLLocator implements ADLLocator {
 
   public URL findSourceADL(final String name, final Map<Object, Object> context) {
     try {
+      /*
+       * Usual case was with getResource. However, the Maven plugin case is more
+       * complex: when using elements from fractal-runtime, it would find
+       * matches in the fractal-runtime.jar in the Maven cache + matches in the
+       * compiler's distribution 'runtime' folder. We get all possible contents,
+       * and return a file-system entry only, thus discarding jar contents.
+       */
       final Enumeration<URL> urls = ClassLoaderHelper.getClassLoader(this,
           context).getResources(getADLSourceName(name).substring(1));
+
       while (urls.hasMoreElements()) {
         final URL url = urls.nextElement();
         if (url.getProtocol().equals("file")) return url;
       }
     } catch (final IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+      // ignore ('null' case handled at higher level)
     }
     return null;
   }

--- a/adl-frontend/src/main/java/org/ow2/mind/adl/BasicADLLocator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/BasicADLLocator.java
@@ -24,7 +24,9 @@ package org.ow2.mind.adl;
 
 import static org.ow2.mind.PathHelper.fullyQualifiedNameToPath;
 
+import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
 import java.util.Map;
 
 import org.objectweb.fractal.adl.Definition;
@@ -84,8 +86,18 @@ public class BasicADLLocator implements ADLLocator {
   }
 
   public URL findSourceADL(final String name, final Map<Object, Object> context) {
-    return ClassLoaderHelper.getClassLoader(this, context).getResource(
-        getADLSourceName(name).substring(1));
+    try {
+      final Enumeration<URL> urls = ClassLoaderHelper.getClassLoader(this,
+          context).getResources(getADLSourceName(name).substring(1));
+      while (urls.hasMoreElements()) {
+        final URL url = urls.nextElement();
+        if (url.getProtocol().equals("file")) return url;
+      }
+    } catch (final IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    return null;
   }
 
   public URL findResource(final String name, final Map<Object, Object> context) {

--- a/adl-frontend/src/main/java/org/ow2/mind/adl/implementation/BasicImplementationLocator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/implementation/BasicImplementationLocator.java
@@ -52,7 +52,15 @@ public class BasicImplementationLocator implements ImplementationLocator {
     if (isRelative(path))
       throw new IllegalArgumentException("\"" + path
           + "\" is not an absolute path");
+
     try {
+      /*
+       * Usual case was with getResource. However, the Maven plugin case is more
+       * complex: when using elements from fractal-runtime, it would find
+       * matches in the fractal-runtime.jar in the Maven cache + matches in the
+       * compiler's distribution 'runtime' folder. We get all possible contents,
+       * and return a file-system entry only, thus discarding jar contents.
+       */
       final Enumeration<URL> urls = getClassLoader(this, context).getResources(
           path.substring(1));
       while (urls.hasMoreElements()) {
@@ -60,8 +68,7 @@ public class BasicImplementationLocator implements ImplementationLocator {
         if (url.getProtocol().equals("file")) return url;
       }
     } catch (final IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+      // ignore ('null' case handled at higher level)
     }
     return null;
 

--- a/adl-frontend/src/main/java/org/ow2/mind/adl/implementation/BasicImplementationLocator.java
+++ b/adl-frontend/src/main/java/org/ow2/mind/adl/implementation/BasicImplementationLocator.java
@@ -26,7 +26,9 @@ import static org.objectweb.fractal.adl.util.ClassLoaderHelper.getClassLoader;
 import static org.ow2.mind.PathHelper.isRelative;
 import static org.ow2.mind.PathHelper.isValid;
 
+import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
 import java.util.Map;
 
 import org.ow2.mind.InputResource;
@@ -50,8 +52,19 @@ public class BasicImplementationLocator implements ImplementationLocator {
     if (isRelative(path))
       throw new IllegalArgumentException("\"" + path
           + "\" is not an absolute path");
+    try {
+      final Enumeration<URL> urls = getClassLoader(this, context).getResources(
+          path.substring(1));
+      while (urls.hasMoreElements()) {
+        final URL url = urls.nextElement();
+        if (url.getProtocol().equals("file")) return url;
+      }
+    } catch (final IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    return null;
 
-    return getClassLoader(this, context).getResource(path.substring(1));
   }
 
   public InputResource toInputResource(final String path) {

--- a/idl-frontend/src/main/java/org/ow2/mind/idl/BasicIDLLocator.java
+++ b/idl-frontend/src/main/java/org/ow2/mind/idl/BasicIDLLocator.java
@@ -27,7 +27,9 @@ import static org.ow2.mind.PathHelper.fullyQualifiedNameToPath;
 import static org.ow2.mind.PathHelper.isRelative;
 import static org.ow2.mind.PathHelper.isValid;
 
+import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
 import java.util.Map;
 
 import org.ow2.mind.InputResource;
@@ -74,8 +76,26 @@ public class BasicIDLLocator implements IDLLocator {
     if (!NameHelper.isValid(name))
       throw new IllegalArgumentException("\"" + name + "\" is not a valid name");
 
-    return getClassLoader(this, context).getResource(
-        getItfSourceName(name).substring(1));
+    try {
+      /*
+       * Usual case was with getResource. However, the Maven plugin case is more
+       * complex: when using elements from fractal-runtime, it would find
+       * matches in the fractal-runtime.jar in the Maven cache + matches in the
+       * compiler's distribution 'runtime' folder. We get all possible contents,
+       * and return a file-system entry only, thus discarding jar contents.
+       */
+      final Enumeration<URL> urls = getClassLoader(this, context).getResources(
+          getItfSourceName(name).substring(1));
+
+      while (urls.hasMoreElements()) {
+        final URL url = urls.nextElement();
+        if (url.getProtocol().equals("file")) return url;
+      }
+    } catch (final IOException e) {
+      // ignore ('null' case handled at higher level)
+    }
+
+    return null;
   }
 
   public URL findBinaryItf(final String name, final Map<Object, Object> context) {
@@ -94,7 +114,26 @@ public class BasicIDLLocator implements IDLLocator {
       throw new IllegalArgumentException("\"" + path
           + "\" is not an absolute path");
 
-    return getClassLoader(this, context).getResource(path.substring(1));
+    try {
+      /*
+       * Usual case was with getResource. However, the Maven plugin case is more
+       * complex: when using elements from fractal-runtime, it would find
+       * matches in the fractal-runtime.jar in the Maven cache + matches in the
+       * compiler's distribution 'runtime' folder. We get all possible contents,
+       * and return a file-system entry only, thus discarding jar contents.
+       */
+      final Enumeration<URL> urls = getClassLoader(this, context).getResources(
+          path.substring(1));
+
+      while (urls.hasMoreElements()) {
+        final URL url = urls.nextElement();
+        if (url.getProtocol().equals("file")) return url;
+      }
+    } catch (final IOException e) {
+      // ignore ('null' case handled at higher level)
+    }
+
+    return null;
   }
 
   public URL findBinaryHeader(final String path,


### PR DESCRIPTION
# Maven support

## The problem

When compiling maven-ized Mind applications such as https://github.com/Mind4SE/mind-maven-examples with the Mind Maven plugins https://github.com/Mind4SE/mind-parent-maven-plugin we had trouble related to using the standard "runtime" library.

Our user projects rely on the "mindadl-maven-plugin" for compilation, itself depending on the mind-compiler, that maven will download the modules of. The mind-compiler project includes the "fractal-runtime" as a Maven module. This implies that at compiler instantiation time, all modules are loaded in the Maven classloader, including the "fractal-runtime" jar.

The classloader "getResource" policy is to search from core Java libraries and then in wider circles, towards the user space. Here, the original "runtime" is contributed as "--src-path" as one of the last Classloader entries, as visible in the SrcPathOptionHandler: https://github.com/MIND-Tools/mind-compiler/blob/master/mindc/src/main/java/org/ow2/mind/cli/SrcPathOptionHandler.java

When searching for the Bootstrap.adl, bootstrap.c, Main.itf usual files, the classloader "getResource" finds the file in the loaded "fractal-runtime" jar first (compressed), before the user file-system entry, leading to an error (a solution could be to unpack the content and add it to the source path).

## Proposed solution

We use "getResources" to obtain all matching resource entries from the classloader, and then flter them to keep "files" only (thus excluding jars).
The solution had a small side effect that is fixed in the 3rd commit.

## Another possible solution / perspective ?

We could also have removed the "fractal-runtime" from the core compiler modules so as not to get the error, and define a specific repository for it, to build it, and add the resources in the final compiler assembly (bin zip).
This could be done in a second phase, and is anyway compatible with the current solution.

## How to test the solution

We provide examples of a basic component library project and application project in the following repository: 
https://github.com/Mind4SE/mind-maven-examples

The "App" and "Lib" are provided as 2 different versions (1.0-SNAPSHOT and 1.1-SNAPSHOT), where only "Lib" contains component a code change (a printf is added), and the only App change is the dependency version:

Component C code change:
* https://github.com/Mind4SE/mind-maven-examples/blob/master/exampleLib/src/main/mind/packagename/componentImpl.c
* https://github.com/Mind4SE/mind-maven-examples/blob/master/exampleLib-1.1/src/main/mind/packagename/componentImpl.c

App POM, see line 30:
* https://github.com/Mind4SE/mind-maven-examples/blob/master/exampleApp/pom.xml
* https://github.com/Mind4SE/mind-maven-examples/blob/master/exampleApp-1.1/pom.xml

