### PR TITLE
Fix: Spaces in path

### DIFF
--- a/common-backend/src/main/java/org/ow2/mind/compilation/DirectiveHelper.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/DirectiveHelper.java
@@ -65,4 +65,28 @@ public final class DirectiveHelper {
 
     return result;
   }
+
+  public static String formatOptionString(final String s) {
+
+    String result = null;
+
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      if (c == '\\') {
+        if (i + 1 < s.length() && isWhitespace(s.charAt(i + 1))) {
+          sb.append(s.charAt(i + 1));
+          i++;
+        } else {
+          sb.append('\\');
+        }
+      } else {
+        sb.append(c);
+      }
+    }
+    if (sb.length() != 0) result = sb.toString();
+
+    return result;
+  }
+
 }

--- a/common-frontend/src/main/java/org/ow2/mind/error/ErrorHelper.java
+++ b/common-frontend/src/main/java/org/ow2/mind/error/ErrorHelper.java
@@ -73,7 +73,8 @@ public final class ErrorHelper {
       inputFile = new File(fileLocation);
 
       if (inputFile.getPath().startsWith(cwdFile.getPath())) {
-        fileLocation = fileLocation.substring(cwd.length());
+        fileLocation = inputFile.getPath().substring(
+            cwdFile.getPath().length() + 1);
       }
     }
 

--- a/common-frontend/src/main/java/org/ow2/mind/error/ErrorHelper.java
+++ b/common-frontend/src/main/java/org/ow2/mind/error/ErrorHelper.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -53,18 +55,30 @@ public final class ErrorHelper {
       }
     }
     final String cwd = System.getProperty("user.dir") + File.separator;
+    final File cwdFile = new File(cwd);
 
     String fileLocation = null;
+    File inputFile = null;
 
     if (locator != null && locator.getInputFilePath() != null) {
-      fileLocation = locator.getInputFilePath();
-      if (fileLocation.startsWith(cwd)) {
+
+      // Convert paths to handle different operating systems, conventions, and
+      // special characters (such as space ' ', plus '+', etc)
+      try {
+        fileLocation = URLDecoder.decode(locator.getInputFilePath(), "UTF-8");
+      } catch (final UnsupportedEncodingException e) {
+        fileLocation = locator.getInputFilePath();
+      }
+
+      inputFile = new File(fileLocation);
+
+      if (inputFile.getPath().startsWith(cwdFile.getPath())) {
         fileLocation = fileLocation.substring(cwd.length());
       }
     }
 
     final StringBuilder sb = new StringBuilder();
-    if (locator != null && fileLocation != null) {
+    if (locator != null && fileLocation != null && inputFile != null) {
       sb.append("At ").append(fileLocation);
 
       if (locator.getBeginLine() >= 0) {
@@ -75,15 +89,16 @@ public final class ErrorHelper {
       }
       sb.append(":\n |--> ");
       if (locator.getBeginLine() >= 0) {
-        final File inputFile = new File(locator.getInputFilePath());
         if (inputFile.exists()) {
           try {
-            final LineNumberReader reader = new LineNumberReader(
-                new FileReader(inputFile));
+            final FileReader fileReader = new FileReader(inputFile);
+            final LineNumberReader lineNumberReader = new LineNumberReader(
+                fileReader);
             for (int i = 0; i < locator.getBeginLine() - 1; i++) {
-              reader.readLine();
+              lineNumberReader.readLine();
             }
-            final String line = reader.readLine().replace("\t", "    ");
+            final String line = lineNumberReader.readLine().replace("\t",
+                "    ");
             sb.append("  ").append(line).append("\n |-->   ");
             if (locator.getBeginColumn() >= 0) {
               for (int i = 0; i < locator.getBeginColumn() - 1; i++) {
@@ -100,6 +115,7 @@ public final class ErrorHelper {
               sb.append("\n |--> ");
 
             }
+            lineNumberReader.close();
           } catch (final IOException e1) {
             // ignore
           }


### PR DESCRIPTION
# Fix: Spaces in path

## The problem

Any source folder or file with spaces in its name.
To reproduce the issue, just take a project, rename it with a space in it, build and rebuild without cleaning in between, to test the incremental compilation part.

## The contributions

* Error reporting

The ErrorHelper was improved to handle paths as decoded URLs, allowing special characters support.

* Incremental compilation fix

It was broken in this case because of our handling of the ".d" preprocessor-generated files, that would contains files such as:

    C:\some path\Bootstrap_impl0.i : C:\some path\mindcommon.h \
        C:\some path\Main.itf.h \
        C:\some path\Bootstrap_impl0.c

Our legacy code would interpret spaces in a "strict Makefile syntax" way: Everytime it met a space ("some space"), it split the entry as differente tokens.

Our new code is based on the GCC syntax (see https ://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html) considering each new line as a whole (resolving the space character issue).

We now consider this behaviour as the new standard.