### PR TITLE
New --keep-source-name flag: simplify debug (output names convention)

### DIFF
--- a/mindc/src/main/java/org/ow2/mind/cli/KeepSourceNameOptionHandler.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/KeepSourceNameOptionHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014 Schneider-Electric
+ *
+ * This file is part of "Mind Compiler" is free software: you can redistribute 
+ * it and/or modify it under the terms of the GNU Lesser General Public License 
+ * as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact: mind@ow2.org
+ *
+ * Authors: Stephane Seyvoz
+ * Contributors: 
+ */
+
+package org.ow2.mind.cli;
+
+import java.util.Map;
+
+import org.ow2.mind.adl.BasicDefinitionCompiler;
+import org.ow2.mind.plugin.util.Assert;
+
+/**
+ * This class handles the --keep-source-name flag (defined in the
+ * mind-plugin.xml) and stores according information in the context, enabling
+ * our alternative naming convention for temporary and binary output files in
+ * the adl-backend. This naming convention uses "_<user_file_name>".c/.o
+ * suffixing instead of "_impl<i>".c/.o, making debug easier for the users.
+ * 
+ * @see BasicDefinitionCompiler
+ * @author Stephane Seyvoz
+ */
+public class KeepSourceNameOptionHandler implements CommandOptionHandler {
+
+  /** The ID of the "keep" option. */
+  public static final String KEEPSRCNAME_ID = "org.ow2.mind.cli.KeepSourceName";
+
+  public void processCommandOption(final CmdOption cmdOption,
+      final CommandLine cmdLine, final Map<Object, Object> context)
+      throws InvalidCommandLineException {
+
+    final CmdFlag opt = Assert.assertInstanceof(cmdOption, CmdFlag.class);
+
+    if (KEEPSRCNAME_ID.equals(opt.getId())) {
+      KeepSrcNameContextHelper.setKeepSourceName(context,
+          opt.isPresent(cmdLine));
+    } else {
+      Assert.fail("Unknown id '" + opt.getId() + "'");
+    }
+
+  }
+
+}

--- a/mindc/src/main/java/org/ow2/mind/cli/KeepSrcNameContextHelper.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/KeepSrcNameContextHelper.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2014 Schneider-Electric
+ *
+ * This file is part of "Mind Compiler" is free software: you can redistribute 
+ * it and/or modify it under the terms of the GNU Lesser General Public License 
+ * as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Contact: mind@ow2.org
+ *
+ * Authors: Stephane Seyvoz
+ * Contributors: 
+ */
+
+package org.ow2.mind.cli;
+
+import java.util.Map;
+
+import org.ow2.mind.adl.BasicDefinitionCompiler;
+
+/**
+ * This class allows setting and getting information about the "KeepSrcName"
+ * naming convention, to be enabled or not in the adl-backend.
+ * 
+ * @see KeepSourceNameOptionHandler
+ * @see BasicDefinitionCompiler
+ * @author Stephane Seyvoz
+ */
+public class KeepSrcNameContextHelper {
+
+  public static final String KEEP_SRC_NAME_CONTEXT_HELPER = "keep-src-name";
+
+  public static boolean getKeepSourceName(final Map<Object, Object> context) {
+    if (context == null) return false;
+    final Boolean b = (Boolean) context.get(KEEP_SRC_NAME_CONTEXT_HELPER);
+    if (b == null)
+      return false;
+    else
+      return b;
+  }
+
+  public static void setKeepSourceName(final Map<Object, Object> context,
+      final boolean forceRegen) {
+    context.put(KEEP_SRC_NAME_CONTEXT_HELPER, forceRegen);
+  }
+
+}

--- a/mindc/src/main/resources/mind-plugin.xml
+++ b/mindc/src/main/resources/mind-plugin.xml
@@ -95,6 +95,12 @@
             longName="no-bin"
             description="Do not generate binary ADL/IDL ('.def', '.itfdef' and '.idtdef' files)." />
 
+		<cmdFlag
+            id="org.ow2.mind.cli.KeepSourceName"
+            longName="keep-source-name"
+            handler="org.ow2.mind.cli.KeepSourceNameOptionHandler"
+            description="Use source files names as suffix for temporary files instead of _impl + idx" />
+
         <!-- ============= -->
         <!-- Flags options -->
         <!-- ============= -->


### PR DESCRIPTION
# New --keep-source-name flag: simplify memory mappings + debug (output names convention)

## The problem

When a primitive component is compiled, its "source cFileName.c" files are preprocessed and compiled as: 
* my_package_Definition_implN.i
* my_package_Definition_implN.o

Where N is the index of the implementation file in the primitive component (ordered).

However this is not very helpful to the user since the "impl0/1/.../N" names aren't that clear for the user to debug his components, as well as defining memory mappings if he wants specific binaries to be located at specific addresses.

## Proposed solution

The --keep-source-name flag provides the user a choice to ease his debug by enabling the following naming convention:
* my_package_Definition_cFileName.i
* my_package_Definition_cFileName.o

We did not make it a standard since it can create very long file names in the end (longer than the usual 4/5 characters), possibly leading to issues on Windows (filesystem limited to 255 characters including folder path).