### PR TITLE
Show full command on error log, and remove log duplicates (stderr + [io])

### DIFF
--- a/common-backend/src/main/java/org/ow2/mind/compilation/ExecutionHelper.java
+++ b/common-backend/src/main/java/org/ow2/mind/compilation/ExecutionHelper.java
@@ -160,14 +160,21 @@ public final class ExecutionHelper {
           if (line != null) {
             // if the title has not been printed yet.
             if (!titleLogged) {
+              if (execTitle != null) logger.severe(execTitle);
+            }
+
+            // in Log level "FINE" the command was already previously shown,
+            // do not repeat, but display for errors in all other modes
+            // for debug purposes
+            if (!logger.isLoggable(Level.FINE)) {
               String command = "";
               for (final String cmd : cmdList) {
                 command += cmd + " ";
               }
-              logger.severe((execTitle == null) ? command : execTitle);
+              logger.severe(command);
             }
+
             do {
-              logger.severe(line);
               processOutput.append(line).append("\n");
               line = reader.readLine();
             } while (line != null);


### PR DESCRIPTION
#Show full command on error log, and remove log duplicates (stderr + [io])

In any case the "FINE" log level would display the command to be executed.
When the stderr listener thread would read some content, it showed the line for any log level, including "FINE", leading to duplicate output.

I also improved the output to show both the task title and full command on error.