### PR TITLE
@DumpAST improvements

### DIFF
--- a/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
+++ b/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
@@ -150,7 +150,7 @@ public class DumpASTAnnotationProcessor
       if (sources.length == 0) {
         System.out.println(prf + "No source (implementation)");
       } else {
-        System.out.println(prf + "Source(s) quantity: " + interfaces.length);
+        System.out.println(prf + "Source(s) quantity: " + sources.length);
       }
 
       for (int i = 0; i < sources.length; i++) {

--- a/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
+++ b/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
@@ -127,14 +127,12 @@ public class DumpASTAnnotationProcessor
         final Component subComponent = subComponents[i];
 
         try {
-          // Simple component
           Definition subCompDef = ASTHelper.getResolvedComponentDefinition(
               subComponent, loaderItf, context);
-          if (subCompDef == null) // or template ?
+          if (subCompDef == null)
             subCompDef = ASTHelper.getResolvedDefinition(
                 subComponent.getDefinitionReference(), loaderItf, context);
 
-          // factory ?
           if (subCompDef != null) {
             System.out.println(prf + "Component #" + i + ": "
                 + subComponent.getName() + " (" + subCompDef.getName() + ")");

--- a/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
+++ b/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
@@ -42,136 +42,139 @@ import org.ow2.mind.annotation.Annotation;
 /**
  * @author Matthieu ANNE
  */
-public class DumpASTAnnotationProcessor extends
-	AbstractADLLoaderAnnotationProcessor {
+public class DumpASTAnnotationProcessor
+    extends
+      AbstractADLLoaderAnnotationProcessor {
 
-    private static void showComponents(final Definition definition,
-	    final int depth) {
-	String prf = "  ";
+  private static void showComponents(final Definition definition,
+      final int depth) {
+    String prf = "  ";
 
-	for (int i = 0; i < depth; i++)
-	    prf = prf + "   ";
+    for (int i = 0; i < depth; i++)
+      prf = prf + "   ";
 
-	System.out.println(prf + "Definition source: "
-		+ definition.astGetSource());
+    if (definition.astGetSource() != null)
+      System.out.println(prf + "Definition source: "
+          + definition.astGetSource());
+    else
+      System.out.println(prf + "No definition source for "
+          + definition.getName() + "- probably generated on the fly");
 
-	final Interface[] interfaces = ((InterfaceContainer) definition)
-		.getInterfaces();
-	if (interfaces.length == 0) {
-	    System.out.println(prf + "No interface");
-	} else {
-	    System.out
-		    .println(prf + "Interface quantity: " + interfaces.length);
-	}
-	for (int i = 0; i < interfaces.length; i++) {
-	    final MindInterface itf = (MindInterface) interfaces[i];
-	    System.out.print(prf + "Interface[" + i + "] is " + itf.getName()
-		    + " with role " + itf.getRole() + ", signature: "
-		    + itf.getSignature());
-	    if (itf.getCardinality() != null) {
-		System.out.print(", cardinality: " + itf.getCardinality());
-	    }
-	    if (itf.getContingency() != null) {
-		System.out.print(", contingency: " + itf.getContingency());
-	    }
-	    if (itf.getNumberOfElement() != null) {
-		System.out.print(", number of element: "
-			+ itf.getNumberOfElement());
-	    }
-	    System.out.println();
-	}
-
-	if (ASTHelper.isComposite(definition)) {
-	    final Component[] subComponents = ((ComponentContainer) definition)
-		    .getComponents();
-	    System.out.print(prf + "Subcomponent quantity: "
-		    + subComponents.length + " (" + subComponents[0].getName());
-	    for (int i = 1; i < subComponents.length; i++) {
-		System.out.print(", " + subComponents[i].getName());
-	    }
-	    System.out.println(")");
-
-	    final Binding[] bindings = ((BindingContainer) definition)
-		    .getBindings();
-	    if (bindings.length == 0) {
-		System.out.println(prf + "No binding");
-	    } else {
-		System.out
-			.println(prf + "Binding quantity: " + bindings.length);
-	    }
-	    for (int i = 0; i < bindings.length; i++) {
-		final Binding binding = bindings[i];
-		System.out.print(prf + "Binding #" + i + " is from "
-			+ binding.getFromComponent() + "."
-			+ binding.getFromInterface());
-		if (binding.getFromInterfaceNumber() != null) {
-		    System.out.print("[" + binding.getFromInterfaceNumber()
-			    + "]");
-		}
-		System.out.print(" to " + binding.getToComponent() + "."
-			+ binding.getToInterface());
-		if (binding.getToInterfaceNumber() != null) {
-		    System.out
-			    .print("[" + binding.getToInterfaceNumber() + "]");
-		}
-		System.out.println();
-	    }
-
-	    for (int i = 0; i < subComponents.length; i++) {
-		final Component subComponent = subComponents[i];
-		try {
-		    System.out.println(prf
-			    + "Component #"
-			    + i
-			    + ": "
-			    + subComponent.getName()
-			    + " ("
-			    + ASTHelper.getResolvedComponentDefinition(
-				    subComponent, null, null).getName() + ")");
-		} catch (final ADLException e1) {
-		    // TODO Auto-generated catch block
-		    e1.printStackTrace();
-		}
-		try {
-		    showComponents(ASTHelper.getResolvedDefinition(subComponent
-			    .getDefinitionReference(), null, null), depth + 1);
-		} catch (final ADLException e) {
-		    // TODO Auto-generated catch block
-		    e.printStackTrace();
-		}
-	    }
-
-	} else if (ASTHelper.isPrimitive(definition)) {
-
-	}
+    final Interface[] interfaces = ((InterfaceContainer) definition)
+        .getInterfaces();
+    if (interfaces.length == 0) {
+      System.out.println(prf + "No interface");
+    } else {
+      System.out.println(prf + "Interface quantity: " + interfaces.length);
+    }
+    for (int i = 0; i < interfaces.length; i++) {
+      final MindInterface itf = (MindInterface) interfaces[i];
+      System.out.print(prf + "Interface[" + i + "] is " + itf.getName()
+          + " with role " + itf.getRole() + ", signature: "
+          + itf.getSignature());
+      if (itf.getCardinality() != null) {
+        System.out.print(", cardinality: " + itf.getCardinality());
+      }
+      if (itf.getContingency() != null) {
+        System.out.print(", contingency: " + itf.getContingency());
+      }
+      if (itf.getNumberOfElement() != null) {
+        System.out.print(", number of element: " + itf.getNumberOfElement());
+      }
+      System.out.println();
     }
 
-    private static void showDefinitionContent(final Definition definition) {
-	System.out.println("Showing content of current definition: "
-		+ definition.getName() + ";\n");
-	showComponents(definition, 0);
+    if (ASTHelper.isComposite(definition)) {
+      final Component[] subComponents = ((ComponentContainer) definition)
+          .getComponents();
+      System.out.print(prf + "Subcomponent quantity: " + subComponents.length
+          + " (" + subComponents[0].getName());
+      for (int i = 1; i < subComponents.length; i++) {
+        System.out.print(", " + subComponents[i].getName());
+      }
+      System.out.println(")");
 
-	System.out
-		.println("\n\n---------------------------------------------------------------\n\n");
+      final Binding[] bindings = ((BindingContainer) definition).getBindings();
+      if (bindings.length == 0) {
+        System.out.println(prf + "No binding");
+      } else {
+        System.out.println(prf + "Binding quantity: " + bindings.length);
+      }
+      for (int i = 0; i < bindings.length; i++) {
+        final Binding binding = bindings[i];
+        System.out.print(prf + "Binding #" + i + " is from "
+            + binding.getFromComponent() + "." + binding.getFromInterface());
+        if (binding.getFromInterfaceNumber() != null) {
+          System.out.print("[" + binding.getFromInterfaceNumber() + "]");
+        }
+        System.out.print(" to " + binding.getToComponent() + "."
+            + binding.getToInterface());
+        if (binding.getToInterfaceNumber() != null) {
+          System.out.print("[" + binding.getToInterfaceNumber() + "]");
+        }
+        System.out.println();
+      }
+
+      for (int i = 0; i < subComponents.length; i++) {
+        final Component subComponent = subComponents[i];
+        try {
+          System.out.println(prf
+              + "Component #"
+              + i
+              + ": "
+              + subComponent.getName()
+              + " ("
+              + ASTHelper.getResolvedComponentDefinition(subComponent, null,
+                  null).getName() + ")");
+        } catch (final ADLException e1) {
+          // TODO Auto-generated catch block
+          e1.printStackTrace();
+        }
+        try {
+          if (ASTHelper.getResolvedDefinition(
+              subComponent.getDefinitionReference(), null, null) == null)
+            System.out.println("Definition of subcomponent "
+                + subComponent.getName() + " was null !");
+          else
+            showComponents(
+                ASTHelper.getResolvedDefinition(
+                    subComponent.getDefinitionReference(), null, null),
+                depth + 1);
+        } catch (final ADLException e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        }
+      }
+
+    } else if (ASTHelper.isPrimitive(definition)) {
 
     }
+  }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.ow2.mind.adl.annotation.ADLLoaderAnnotationProcessor#processAnnotation
-     * (org.ow2.mind.annotation.Annotation, org.objectweb.fractal.adl.Node,
-     * org.objectweb.fractal.adl.Definition,
-     * org.ow2.mind.adl.annotation.ADLLoaderPhase, java.util.Map)
-     */
-    public Definition processAnnotation(final Annotation annotation,
-	    final Node node, final Definition definition,
-	    final ADLLoaderPhase phase, final Map<Object, Object> context)
-	    throws ADLException {
-	assert annotation instanceof DumpAST;
-	showDefinitionContent(definition);
-	return null;
-    }
+  public static void showDefinitionContent(final Definition definition) {
+    System.out.println("Showing content of current definition: "
+        + definition.getName() + ";\n");
+    showComponents(definition, 0);
+
+    System.out
+        .println("\n\n---------------------------------------------------------------\n\n");
+
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see
+   * org.ow2.mind.adl.annotation.ADLLoaderAnnotationProcessor#processAnnotation
+   * (org.ow2.mind.annotation.Annotation, org.objectweb.fractal.adl.Node,
+   * org.objectweb.fractal.adl.Definition,
+   * org.ow2.mind.adl.annotation.ADLLoaderPhase, java.util.Map)
+   */
+  public Definition processAnnotation(final Annotation annotation,
+      final Node node, final Definition definition, final ADLLoaderPhase phase,
+      final Map<Object, Object> context) throws ADLException {
+    assert annotation instanceof DumpAST;
+    showDefinitionContent(definition);
+    return null;
+  }
 
 }

--- a/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
+++ b/annotations/src/main/java/org/ow2/mind/adl/annotations/DumpASTAnnotationProcessor.java
@@ -52,10 +52,10 @@ public class DumpASTAnnotationProcessor
       AbstractADLLoaderAnnotationProcessor {
 
   @Inject
-  private static Loader loaderItf;
+  private Loader loaderItf;
 
   private static void showComponents(final Definition definition,
-      final int depth, final Map<Object, Object> context) {
+      final int depth, final Loader loaderItf, final Map<Object, Object> context) {
     String prf = "  ";
 
     for (int i = 0; i < depth; i++)
@@ -134,10 +134,15 @@ public class DumpASTAnnotationProcessor
             subCompDef = ASTHelper.getResolvedDefinition(
                 subComponent.getDefinitionReference(), loaderItf, context);
 
-          System.out.println(prf + "Component #" + i + ": "
-              + subComponent.getName() + " (" + subCompDef.getName() + ")");
+          // factory ?
+          if (subCompDef != null) {
+            System.out.println(prf + "Component #" + i + ": "
+                + subComponent.getName() + " (" + subCompDef.getName() + ")");
 
-          showComponents(subCompDef, depth + 1, context);
+            showComponents(subCompDef, depth + 1, loaderItf, context);
+          } else
+            System.out.println("Could not resolve \""
+                + subComponent.getDefinitionReference() + "\" definition !");
         } catch (final ADLException e) {
           System.out.println("Could not resolve \""
               + subComponent.getDefinitionReference() + "\" definition !");
@@ -166,10 +171,10 @@ public class DumpASTAnnotationProcessor
   }
 
   public static void showDefinitionContent(final Definition definition,
-      final Map<Object, Object> context) {
+      final Loader loaderItf, final Map<Object, Object> context) {
     System.out.println("Showing content of current definition: "
         + definition.getName() + ";\n");
-    showComponents(definition, 0, context);
+    showComponents(definition, 0, loaderItf, context);
 
     System.out
         .println("\n\n---------------------------------------------------------------\n\n");
@@ -188,7 +193,7 @@ public class DumpASTAnnotationProcessor
       final Node node, final Definition definition, final ADLLoaderPhase phase,
       final Map<Object, Object> context) throws ADLException {
     assert annotation instanceof DumpAST;
-    showDefinitionContent(definition, context);
+    showDefinitionContent(definition, loaderItf, context);
     return null;
   }
 


### PR DESCRIPTION
# @DumpAST improvements

## Contributions

* showDefinitionContent method visibility

Now available to be used from static calls, useful during plugins development to quickly monitor transformed architecture as a log.

* definition.astGetSource() protected

We could get "null" when source code was generated on the fly, or with factories.

* Implementation sources now displayed

* Generic definitions support

They would lead to a NullPointerException or an ugly stack trace.
Now working thanks to correct Loader injection (with Google Guice).

## Note concerning static calls

External static calls from plugins MUST provide a Loader instance for the serialization to work with generic definitions (new behaviour won't crash anymore in this case but will just say it could not resolve the definition).