### PR TITLE
Java 8 build fix: antlr3-maven-plugin 3.3 -> 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr3-maven-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.5.2</version>
                     <executions>
                         <execution>
                             <id>generate parser</id>


### PR DESCRIPTION
# Java 8 build fix

### Issue

Build error on CPL-Preproc while generating parser classes.

### Solution

antlr3-maven-plugin 3.3 -> 3.5.2

### Explanation / Source
See https://jira.exoplatform.org/browse/JCR-2354